### PR TITLE
Add context support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,14 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+  lint:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.1'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.4.0

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This is a fork of the original Gorilla implementation with some enhancements
 * Make the session thread safe.
 * Optimize the `streamReader` function to perform fewer allocations.
 * Avoid panics if `Shell.Exit` is called on a closed shell.
+* Added an additional shell method `ExecuteWithContext` that takes a context argument. If a shell command isn't well formed then the stdout and stderr pipes do not return anything and the `Execute` method will block indefinitely in this case. The underlying session will be restarted before `context.DeadlineExceeded` is returned to the caller. A restarted shell _may_ be unstable!
 
-This package is inspired by [jPowerShell](https://github.com/profesorfalken/jPowerShell)
+This package was originally inspired by [jPowerShell](https://github.com/profesorfalken/jPowerShell)
 and allows one to run and remote-control a PowerShell session. Use this if you
 don't have a static script that you want to execute, bur rather run dynamic
 commands.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ to use the Local backend, which just uses `os/exec` to start the process.
 package main
 
 import (
+    "context"
 	"fmt"
 
 	ps "github.com/fireflycons/go-powershell"
@@ -52,6 +53,18 @@ func main() {
 	}
 
 	fmt.Println(stdout)
+
+    // ... or more safely
+    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    defer cancel()
+
+	stdout, stderr, err := shell.ExecuteWithContext(ctx, "Write-Host 'Hello world'")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(stdout)
+
 }
 ```
 
@@ -60,7 +73,7 @@ func main() {
 You can use an existing PS shell to use PSSession cmdlets to connect to remote
 computers. Instead of manually handling that, you can use the Session middleware,
 which takes care of authentication. Note that you can still use the "raw" shell
-to execute commands on the computer where the powershell host process is running.
+to execute commands on the computer where the PowerShell host process is running.
 
 ```go
 package main

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.25.1
 
 require github.com/juju/errors v1.0.0
 
+require golang.org/x/sync v0.17.0
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/middleware/session.go
+++ b/middleware/session.go
@@ -45,6 +45,7 @@ func (s *session) Execute(cmd string) (string, string, error) {
 
 // Exit disconnects the session (i.e. Disconnect-PSSession)
 func (s *session) Exit() {
-	s.upstream.Execute(fmt.Sprintf("Disconnect-PSSession -Session $%s", s.name))
+	// Discard errors here. We are binning the session
+	_, _, _ = s.upstream.Execute(fmt.Sprintf("Disconnect-PSSession -Session $%s", s.name))
 	s.upstream.Exit()
 }

--- a/shell.go
+++ b/shell.go
@@ -7,52 +7,121 @@
 package powershell
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/fireflycons/go-powershell/backend"
 	"github.com/fireflycons/go-powershell/utils"
 	"github.com/juju/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 const newline = "\r\n"
 
+// ShellOptions represents options passed to the shell when it is started.
+type ShellOptions struct {
+	modulesToLoad []string
+}
+
+type ShellOptionFunc func(*ShellOptions)
+
 // Shell is the interface to a PowerShell session
 type Shell interface {
 	Execute(cmd string) (string, string, error)
+	ExecuteWithContext(ctx context.Context, cmd string) (string, string, error)
 	Exit()
 }
 
 // concrete implementation of shell
 type shell struct {
-	handle backend.Waiter
-	stdin  io.Writer
-	stdout io.Reader
-	stderr io.Reader
-	lock   *sync.Mutex
+	handle  backend.Waiter
+	backend backend.Starter
+	stdin   io.Writer
+	stdout  io.Reader
+	stderr  io.Reader
+	lock    *sync.Mutex
 }
 
 // New creates a new PowerShell session
-func New(backend backend.Starter) (Shell, error) {
-	handle, stdin, stdout, stderr, err := backend.StartProcess("powershell.exe", "-NoExit", "-Command", "-")
-	if err != nil {
+func New(backend backend.Starter, opts ...ShellOptionFunc) (Shell, error) {
+
+	s := &shell{
+		backend: backend,
+		lock:    &sync.Mutex{},
+	}
+
+	if err := s.start(); err != nil {
 		return nil, err
 	}
 
-	return &shell{
-		handle: handle,
-		stdin:  stdin,
-		stdout: stdout,
-		stderr: stderr,
-		lock:   &sync.Mutex{},
-	}, nil
+	return s, nil
+}
+
+// WithModules specifies a list of PowerShell modules to
+// import into the shell when it starts
+func WithModules(modules ...string) ShellOptionFunc {
+	return func(so *ShellOptions) {
+		so.modulesToLoad = modules
+	}
 }
 
 // Execute runs PowerShell script in the session instance, capturing stdout and stderr streams
+//
+// This call may block indefinitely if the command is not well formed.
 func (s *shell) Execute(cmd string) (string, string, error) {
+
+	return s.ExecuteWithContext(context.TODO(), cmd)
+}
+
+// ExecuteWithContext runs PowerShell script in the session instance, capturing stdout and stderr streams.
+//
+// The context allows cancellation of the command. Streams to/from the PowerShell session may
+// block indefinitely if the command is not well formed as the input may still be waiting.
+//
+// Note that if the error is "context deadline exceeded", the underlying session will be
+// unstable and it will be restarted. A restarted shell _may_ be unstable!
+func (s *shell) ExecuteWithContext(ctx context.Context, cmd string) (string, string, error) {
+
+	// Lock the shell so that only one thread can execute a command at a time
+	s.lock.Lock()
+	sout, serr, err := s.executeWithContext(ctx, cmd)
+	s.lock.Unlock()
+	return sout, serr, err
+}
+
+// Exit releases the PowerShell session, terminating the underlying powershell.exe process
+func (s *shell) Exit() {
+
+	// Prevent panics if Exit is called multiple times
+	if s == nil || s.handle == nil {
+		fmt.Fprintf(os.Stderr, "Warning: go-powershell: Attempted to exit a shell that is already closed.\n")
+		return
+	}
+
+	// Discard error here and everywhere else. We are binning the session
+	_, _ = s.stdin.Write([]byte("exit" + newline))
+
+	// if it's possible to close stdin, do so (some backends, like the local one,
+	// do support it)
+	closer, ok := s.stdin.(io.Closer)
+	if ok {
+		_ = closer.Close()
+	}
+
+	_ = s.handle.Wait()
+
+	s.handle = nil
+	s.stdin = nil
+	s.stdout = nil
+	s.stderr = nil
+}
+
+func (s *shell) executeWithContext(ctx context.Context, cmd string) (string, string, error) {
 	if s.handle == nil {
 		return "", "", errors.Annotate(errors.New(cmd), "Cannot execute commands on closed shells.")
 	}
@@ -66,10 +135,6 @@ func (s *shell) Execute(cmd string) (string, string, error) {
 	// even if the command itself contains an exit statement.
 	full := fmt.Sprintf("try { %s } catch { [Console]::Error.WriteLine($_.Exception.Message) } finally { [Console]::WriteLine('%s'); [Console]::Error.WriteLine('%s') }%s", cmd, outBoundary, errBoundary, newline)
 
-	// Lock the shell so that only one thread can execute a command at a time
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	_, err := s.stdin.Write([]byte(full))
 	if err != nil {
 		return "", "", errors.Annotate(errors.Annotate(err, cmd), "Could not send PowerShell command")
@@ -79,13 +144,28 @@ func (s *shell) Execute(cmd string) (string, string, error) {
 	sout := ""
 	serr := ""
 
-	waiter := &sync.WaitGroup{}
-	waiter.Add(2)
+	eg := &errgroup.Group{}
 
-	go streamReader(s.stdout, outBoundary, &sout, waiter)
-	go streamReader(s.stderr, errBoundary, &serr, waiter)
+	eg.Go(func() error {
+		return streamReader(ctx, s.stdout, outBoundary, &sout)
+	})
 
-	waiter.Wait()
+	eg.Go(func() error {
+		return streamReader(ctx, s.stderr, errBoundary, &serr)
+	})
+
+	err = eg.Wait()
+
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+
+			if err1 := s.restart(); err1 != nil {
+				err = errors.Wrap(err, err1)
+			}
+		}
+
+		return "", err.Error(), err
+	}
 
 	if len(serr) > 0 {
 		return sout, serr, errors.Annotate(errors.New(cmd), serr)
@@ -94,35 +174,31 @@ func (s *shell) Execute(cmd string) (string, string, error) {
 	return sout, serr, nil
 }
 
-// Exit releases the PowerShell session, terminating the underlying powershell.exe process
-func (s *shell) Exit() {
+func (s *shell) start() error {
 
-	// Prevent panics if Exit is called multiple times
-	if s == nil || s.handle == nil {
-		fmt.Fprintf(os.Stderr, "Warning: go-powershell: Attempted to exit a shell that is already closed.\n")
-		return
+	handle, stdin, stdout, stderr, err := s.backend.StartProcess("powershell.exe", "-NoExit", "-Command", "-")
+	if err != nil {
+		return err
 	}
 
-	s.stdin.Write([]byte("exit" + newline))
+	s.handle = handle
+	s.stdin = stdin
+	s.stdout = stdout
+	s.stderr = stderr
 
-	// if it's possible to close stdin, do so (some backends, like the local one,
-	// do support it)
-	closer, ok := s.stdin.(io.Closer)
-	if ok {
-		closer.Close()
-	}
-
-	s.handle.Wait()
-
-	s.handle = nil
-	s.stdin = nil
-	s.stdout = nil
-	s.stderr = nil
+	return nil
 }
 
-func streamReader(stream io.Reader, boundary string, buffer *string, signal *sync.WaitGroup) error {
+func (s *shell) restart() error {
 
-	defer signal.Done()
+	s.Exit()
+	err := s.start()
+	// Wait a fraction for new shell to stabilize
+	time.Sleep(time.Millisecond * 500)
+	return err
+}
+
+func streamReader(ctx context.Context, stream io.Reader, boundary string, buffer *string) error {
 
 	// read all output until we have found our boundary token
 	output := strings.Builder{}
@@ -131,7 +207,17 @@ func streamReader(stream io.Reader, boundary string, buffer *string, signal *syn
 	buf := make([]byte, bufsize)
 
 	for {
-		read, err := stream.Read(buf)
+		var (
+			read int
+			err  error
+		)
+
+		if ctx != context.TODO() {
+			read, err = readWithContext(ctx, stream, buf)
+		} else {
+			read, err = stream.Read(buf)
+		}
+
 		if err != nil {
 			return err
 		}
@@ -146,6 +232,32 @@ func streamReader(stream io.Reader, boundary string, buffer *string, signal *syn
 	*buffer = strings.TrimSuffix(output.String(), marker)
 
 	return nil
+}
+
+// ReadWithContext reads from r into buf, returning when either
+// the read completes, the context is canceled, or an error occurs.
+func readWithContext(ctx context.Context, r io.Reader, buf []byte) (int, error) {
+	pr, pw := io.Pipe()
+
+	// Start a background copier that forwards from r -> pw.
+	go func() {
+		_, err := io.Copy(pw, r)
+		// When the copy ends or fails, close the pipe.
+		_ = pw.CloseWithError(err)
+	}()
+
+	// Ensure the pipe is closed when context expires.
+	go func() {
+		<-ctx.Done()
+		_ = pw.CloseWithError(ctx.Err())
+	}()
+
+	// Now do a normal blocking read — this is cancellable via ctx.
+	n, err := pr.Read(buf)
+	if errors.Is(err, io.ErrClosedPipe) {
+		return n, ctx.Err()
+	}
+	return n, err
 }
 
 func createBoundary() string {

--- a/utils/quote.go
+++ b/utils/quote.go
@@ -5,5 +5,5 @@ package utils
 import "strings"
 
 func QuoteArg(s string) string {
-	return "'" + strings.Replace(s, "'", "\"", -1) + "'"
+	return "'" + strings.ReplaceAll(s, "'", "\"") + "'"
 }


### PR DESCRIPTION
Added an additional shell method `ExecuteWithContext` that takes a context argument. If a shell command isn't well formed then the stdout and stderr pipes do not return anything and the `Execute` method will block indefinitely in this case. The underlying session will be restarted before `context.DeadlineExceeded` is returned to the caller. A restarted shell may be unstable!