### PR TITLE
(fix): Remove surplus error log

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -392,7 +392,6 @@ func (s *shell) executeWithContext(ctx context.Context, cmd string) (sout string
 		// Any "normal" error, such as an unhandled exception
 		// or direct write to stderr will be caught here.
 		rerr = errors.Annotate(ErrCommandFailed, cmd)
-		s.options.logger.Errorf("Command execution failed due to data written to stderr: %s", cmd)
 		return
 	}
 

--- a/shell_logging_test.go
+++ b/shell_logging_test.go
@@ -46,6 +46,10 @@ func TestLogToStandardLibraryLog(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, logbuf.String(), cmd)
 
+	cmd = `throw 'this is an error'`
+	_, _, err = shell.Execute(cmd)
+	require.ErrorIs(t, err, powershell.ErrCommandFailed)
+	require.Contains(t, logbuf.String(), "this is an error")
 	require.NoError(t, shell.Exit())
 
 	logbuf.Reset()


### PR DESCRIPTION
Command failure (output on stderr) was being logged twice